### PR TITLE
Remove Jenkins section header

### DIFF
--- a/tasks/atomizer.js
+++ b/tasks/atomizer.js
@@ -41,8 +41,6 @@ module.exports = function (grunt) {
         var configFile;
         var cacheFile = path.join('./.atomic-cache/', this.target || 'atomic');
 
-        grunt.log.writeln('[start] ' + grunt.task.current.name);
-
         if (options.rules && options.rules.length > 0) {
             options.rules = grunt.file.expand(options.rules);
         }


### PR DESCRIPTION
@src-code 

When running multiple atomizers, this ends up spamming the left navigation bar. Not really useful anymore.